### PR TITLE
Prevent build-fail on Ubuntu 18.04

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,7 @@ LD	:= ld
 CFLAGS	:= -fPIE -O3 -g -std=c99 -pedantic -Wall -fdata-sections -ffunction-sections
 LDFLAGS	:= -fPIE -pie -O3 -Wl,--gc-sections
 
-CCNOSTD	:= -ffreestanding -fno-stack-protector -static -nostdlib
+CCNOSTD	:= -ffreestanding -fno-stack-protector -D_FORTIFY_SOURCE=0 -static -nostdlib
 LDNOSTD	:= $(CCNOSTD) -Wl,-y,__stack_chk_fail
 
 CCSTATIC:= -static


### PR DESCRIPTION
Build fails on Ubuntu 18.04:
```
user@VMMRTESTDEV02:~/sigflag/vmx86$ mx build
build: Checking SubstrateVM requirements for building ...
JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
EXTRA_JAVA_HOMES: 
Dependencies removed from build:
 project org.graalvm.libgraal.jdk13 was removed as JDK 13 is not available
 project org.graalvm.libgraal.jdk8 was removed as JDK 1.8 is not available
 project org.graalvm.compiler.serviceprovider.jdk13 was removed as JDK 13 is not available
 project org.graalvm.compiler.serviceprovider.jdk8 was removed as JDK 1.8 is not available
 project org.graalvm.compiler.hotspot.jdk12 was removed as JDK 12 is not available
 project org.graalvm.compiler.hotspot.jdk13 was removed as JDK 13 is not available
 project org.graalvm.compiler.hotspot.jdk8 was removed as JDK 1.8 is not available
 project org.graalvm.compiler.truffle.runtime.serviceprovider.jdk8 was removed as JDK 1.8 is not available
 project org.graalvm.compiler.truffle.runtime.hotspot.jdk8+13 was removed as JDK 1.8 is not available
 project org.graalvm.compiler.truffle.runtime.hotspot.libgraal was removed as JDK 1.8 is not available
 project org.graalvm.compiler.replacements.jdk12.test was removed as JDK 12 is not available
 com.oracle.svm.native.jvm.windows removed: only windows is supported
 project org.graalvm.compiler.hotspot.management.jdk13 was removed as JDK 13 is not available
 project com.oracle.svm.core.jdk8 was removed as JDK 1.8 is not available
 project com.oracle.svm.graal.hotspot.libgraal was removed as JDK 1.8 is not available
 project org.graalvm.compiler.truffle.compiler.hotspot.libgraal.processor was removed as JDK 1.8 is not available
 distribution TRUFFLE_LIBGRAAL_PROCESSOR was removed as all its dependencies were removed
 project org.graalvm.compiler.truffle.compiler.hotspot.libgraal was removed as JDK 1.8 is not available
 distribution GRAAL_HOTSPOT_LIBRARY was removed as all its dependencies were removed
Building org.graalvm.vm.x86.testcases.c with GNU Make... [rebuild needed by GNU Make]
[CC-NSTD]   src/tls.nostdlib.o
[AS]        lib/_start.o
[AS]        lib/syscall.o
[CCLD-NSTD] src/tls.nostdlib.elf
src/tls.nostdlib.o: In function `printf':
/usr/include/x86_64-linux-gnu/bits/stdio2.h:104: undefined reference to `__printf_chk'
/usr/include/x86_64-linux-gnu/bits/stdio2.h:104: undefined reference to `__printf_chk'
/usr/include/x86_64-linux-gnu/bits/stdio2.h:104: undefined reference to `__printf_chk'
/usr/include/x86_64-linux-gnu/bits/stdio2.h:104: undefined reference to `__printf_chk'
/usr/include/x86_64-linux-gnu/bits/stdio2.h:104: undefined reference to `__printf_chk'
collect2: error: ld returned 1 exit status
/home/user/sigflag/vmx86/tests/Makefile:37: recipe for target 'src/tls.nostdlib.elf' failed
make: *** [src/tls.nostdlib.elf] Error 1
rm lib/syscall.o lib/_start.o src/tls.nostdlib.o

Building org.graalvm.vm.x86.testcases.c with GNU Make failed
1 build tasks failed
```

This patch fixes the issue.